### PR TITLE
cluster_formation

### DIFF
--- a/exercises/scala/src/main/resources/application.conf
+++ b/exercises/scala/src/main/resources/application.conf
@@ -12,9 +12,27 @@ akka {
   }
 
   actor {
+    provider = "cluster"
     serialization-bindings {
       "com.reactivebbq.loyalty.SerializableMessage" = jackson-cbor
     }
+  }
+
+  remote {
+    artery {
+      transport = tcp
+      canonical {
+        hostname = "127.0.0.1"
+        port = 2551
+      }
+    }
+  }
+
+  cluster {
+    seed-nodes = [
+      "akka://Loyalty@127.0.0.1:2551",
+      "akka://Loyalty@127.0.0.1:2552"
+    ]
   }
 }
 

--- a/exercises/scala/src/main/scala/com/reactivebbq/loyalty/Main.scala
+++ b/exercises/scala/src/main/scala/com/reactivebbq/loyalty/Main.scala
@@ -3,6 +3,7 @@ package com.reactivebbq.loyalty
 import java.nio.file.Paths
 
 import akka.actor.ActorSystem
+import akka.cluster.sharding.{ClusterSharding, ClusterShardingSettings}
 import akka.http.scaladsl.Http
 import org.slf4j.LoggerFactory
 
@@ -21,16 +22,16 @@ object Main extends App {
   val rootPath = Paths.get("tmp")
   val loyaltyRepository: LoyaltyRepository = new FileBasedLoyaltyRepository(rootPath)(system.dispatcher)
 
-  val loyaltyActorSupervisor = system.actorOf(LoyaltyActorSupervisor.props(loyaltyRepository))
+  //val loyaltyActorSupervisor = system.actorOf(LoyaltyActorSupervisor.props(loyaltyRepository))
 
   // TODO: Uncomment to enable cluster sharding.
-  //  val loyaltyActorSupervisor = ClusterSharding(system).start(
-  //    "loyalty",
-  //    LoyaltyActor.props(loyaltyRepository),
-  //    ClusterShardingSettings(system),
-  //    LoyaltyActorSupervisor.idExtractor,
-  //    LoyaltyActorSupervisor.shardIdExtractor
-  //  )
+    val loyaltyActorSupervisor = ClusterSharding(system).start(
+      "loyalty",
+      LoyaltyActor.props(loyaltyRepository),
+      ClusterShardingSettings(system),
+      LoyaltyActorSupervisor.idExtractor,
+      LoyaltyActorSupervisor.shardIdExtractor
+    )
 
   val loyaltyRoutes = new LoyaltyRoutes(loyaltyActorSupervisor)(system.dispatcher)
 


### PR DESCRIPTION
Allows us to have our Loyalty Accounts distributed across that cluster. Each node of the cluster will host a subset of the accounts, maintaining their data in memory. This allows us to distribute the load, but also use those accounts to maintain consistency, and minimize database reads. This is done using Akka Cluster Sharding.