### PR TITLE
cluster_management

### DIFF
--- a/exercises/scala/src/main/resources/application.conf
+++ b/exercises/scala/src/main/resources/application.conf
@@ -34,6 +34,14 @@ akka {
       "akka://Loyalty@127.0.0.1:2552"
     ]
   }
+
+  management {
+    http {
+      hostname = "127.0.0.1"
+      port = 8558
+      route-providers-read-only = false
+    }
+  }
 }
 
 

--- a/exercises/scala/src/main/scala/com/reactivebbq/loyalty/Main.scala
+++ b/exercises/scala/src/main/scala/com/reactivebbq/loyalty/Main.scala
@@ -5,6 +5,7 @@ import java.nio.file.Paths
 import akka.actor.ActorSystem
 import akka.cluster.sharding.{ClusterSharding, ClusterShardingSettings}
 import akka.http.scaladsl.Http
+import akka.management.scaladsl.AkkaManagement
 import org.slf4j.LoggerFactory
 
 object Main extends App {
@@ -18,6 +19,7 @@ object Main extends App {
   }
 
   implicit val system: ActorSystem = ActorSystem("Loyalty")
+  AkkaManagement(system).start()
 
   val rootPath = Paths.get("tmp")
   val loyaltyRepository: LoyaltyRepository = new FileBasedLoyaltyRepository(rootPath)(system.dispatcher)


### PR DESCRIPTION
Edited src/main/resources/application.conf.
Added akka.management.http.hostname to "127.0.0.1", akka.management.http.port to 8558 akka.management.http.route-providers-read-only to false
Enable Akka Management.
Edited Main.scala
Enabled Akka Management using AkkaManagement(system).start()